### PR TITLE
[UI] TabooButton > PrimaryButton & SecondaryButton 스타일 추가

### DIFF
--- a/Taboo/src/main/res/values-night/themes.xml
+++ b/Taboo/src/main/res/values-night/themes.xml
@@ -90,12 +90,54 @@
         <item name="android:padding">15dp</item>
     </style>
 
-    <style name="Taboo.Style.Button.Rect">
-        <item name="android:background">@drawable/shape_rect_r0_a0_000000</item>
+    <style name="Taboo.Style.PrimaryButton">
+        <item name="primaryColor">@color/taboo_vibrant_blue_01</item>
+        <item name="secondaryColor">@color/taboo_blue_06</item>
     </style>
 
-    <style name="Taboo.Style.Button.Round">
-        <item name="android:background">@drawable/shape_rect_r15_a0_000000</item>
+    <style name="Taboo.Style.PrimaryButton.Round">
+        <item name="buttonShape">round</item>
+    </style>
+
+    <style name="Taboo.Style.PrimaryButton.Round.Solid">
+        <item name="buttonType">solid</item>
+    </style>
+
+    <style name="Taboo.Style.PrimaryButton.Round.Fill">
+        <item name="buttonType">fill</item>
+    </style>
+
+    <style name="Taboo.Style.PrimaryButton.Round.Outline">
+        <item name="buttonType">outline</item>
+    </style>
+
+    <style name="Taboo.Style.PrimaryButton.Round.Dash">
+        <item name="buttonType">dash</item>
+    </style>
+
+    <style name="Taboo.Style.SecondaryButton">
+        <item name="primaryColor">@color/white</item>
+        <item name="secondaryColor">@android:color/transparent</item>
+    </style>
+
+    <style name="Taboo.Style.SecondaryButton.Round">
+        <item name="buttonShape">round</item>
+    </style>
+
+    <style name="Taboo.Style.SecondaryButton.Round.Solid">
+        <item name="buttonType">solid</item>
+    </style>
+
+    <style name="Taboo.Style.SecondaryButton.Round.Fill">
+        <item name="buttonType">fill</item>
+    </style>
+
+    <style name="Taboo.Style.SecondaryButton.Round.Outline">
+        <item name="buttonType">outline</item>
+    </style>
+
+    <style name="Taboo.Style.SecondaryButton.Round.Dash">
+        <item name="buttonType">dash</item>
     </style>
 
     <style name="Taboo.Style.IconButton">

--- a/Taboo/src/main/res/values/themes.xml
+++ b/Taboo/src/main/res/values/themes.xml
@@ -123,12 +123,54 @@
         <item name="android:padding">15dp</item>
     </style>
 
-    <style name="Taboo.Style.Button.Rect">
-        <item name="android:background">@drawable/shape_rect_r0_a0_000000</item>
+    <style name="Taboo.Style.PrimaryButton">
+        <item name="primaryColor">@color/taboo_vibrant_blue_01</item>
+        <item name="secondaryColor">@color/taboo_blue_06</item>
     </style>
 
-    <style name="Taboo.Style.Button.Round">
-        <item name="android:background">@drawable/shape_rect_r15_a0_000000</item>
+    <style name="Taboo.Style.PrimaryButton.Round">
+        <item name="buttonShape">round</item>
+    </style>
+
+    <style name="Taboo.Style.PrimaryButton.Round.Solid">
+        <item name="buttonType">solid</item>
+    </style>
+
+    <style name="Taboo.Style.PrimaryButton.Round.Fill">
+        <item name="buttonType">fill</item>
+    </style>
+
+    <style name="Taboo.Style.PrimaryButton.Round.Outline">
+        <item name="buttonType">outline</item>
+    </style>
+
+    <style name="Taboo.Style.PrimaryButton.Round.Dash">
+        <item name="buttonType">dash</item>
+    </style>
+
+    <style name="Taboo.Style.SecondaryButton">
+        <item name="primaryColor">@color/taboo_black_04</item>
+        <item name="secondaryColor">@color/taboo_gray_03</item>
+    </style>
+
+    <style name="Taboo.Style.SecondaryButton.Round">
+        <item name="buttonShape">round</item>
+    </style>
+
+    <style name="Taboo.Style.SecondaryButton.Round.Solid">
+        <item name="buttonType">solid</item>
+    </style>
+
+    <style name="Taboo.Style.SecondaryButton.Round.Fill">
+        <item name="buttonType">fill</item>
+    </style>
+
+    <style name="Taboo.Style.SecondaryButton.Round.Outline">
+        <item name="buttonType">outline</item>
+    </style>
+
+    <style name="Taboo.Style.SecondaryButton.Round.Dash">
+        <item name="buttonType">dash</item>
     </style>
 
     <style name="Taboo.Style.IconButton">


### PR DESCRIPTION
`theme.xml`에 **PrimaryButton**과 **SecondaryButton**에 대한 스타일을 추가하였습니다.

구분은 아래와 같이 합니다.

`Taboo.Style.PrimaryButton.<ButtonShape>.<ButtonType>`
`Taboo.Style.SecondaryButton.<ButtonShape>.<ButtonType>`

예시) `TabooButton.PrimaryButton.Round.Fill`