### PR TITLE
[UI] TabooEditText 수정

### DIFF
--- a/Taboo/src/main/java/com/kwon/taboo/edittext/TabooEditText.kt
+++ b/Taboo/src/main/java/com/kwon/taboo/edittext/TabooEditText.kt
@@ -2,11 +2,12 @@ package com.kwon.taboo.edittext
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.graphics.Typeface
 import android.text.Editable
 import android.text.TextWatcher
 import android.util.AttributeSet
-import android.view.KeyEvent
 import android.view.LayoutInflater
+import android.view.inputmethod.EditorInfo
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.kwon.taboo.R
 import com.kwon.taboo.databinding.TabooEditTextBinding
@@ -195,7 +196,25 @@ class TabooEditText(context: Context, attrs: AttributeSet) : ConstraintLayout(co
     }
 
     private fun updateInputType() {
-        binding.edtText.inputType = this.inputType
+        binding.edtText.inputType = inputType
+
+        // inputType이 비밀번호 타입이면 typeFace를 Default로 초기화.
+        if (isPasswordInputType(inputType) || isVisiblePasswordInputType(inputType)) {
+            binding.edtText.typeface = Typeface.DEFAULT
+        }
+    }
+
+    private fun isPasswordInputType(inputType: Int): Boolean {
+        val variation = inputType and (EditorInfo.TYPE_MASK_CLASS or EditorInfo.TYPE_MASK_VARIATION)
+        return (variation == (EditorInfo.TYPE_CLASS_TEXT or EditorInfo.TYPE_TEXT_VARIATION_PASSWORD)) ||
+                (variation == (EditorInfo.TYPE_CLASS_TEXT or EditorInfo.TYPE_TEXT_VARIATION_WEB_PASSWORD)) ||
+                (variation == (EditorInfo.TYPE_CLASS_NUMBER or EditorInfo.TYPE_NUMBER_VARIATION_PASSWORD))
+    }
+
+    private fun isVisiblePasswordInputType(inputType: Int): Boolean {
+        val variation =
+            inputType and (EditorInfo.TYPE_MASK_CLASS or EditorInfo.TYPE_MASK_VARIATION)
+        return (variation == (EditorInfo.TYPE_CLASS_TEXT or EditorInfo.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD))
     }
 
     fun getText() = binding.edtText.text.toString()

--- a/Taboo/src/main/java/com/kwon/taboo/edittext/TabooEditText.kt
+++ b/Taboo/src/main/java/com/kwon/taboo/edittext/TabooEditText.kt
@@ -8,6 +8,7 @@ import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.inputmethod.EditorInfo
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.kwon.taboo.R
 import com.kwon.taboo.databinding.TabooEditTextBinding
@@ -31,6 +32,9 @@ class TabooEditText(context: Context, attrs: AttributeSet) : ConstraintLayout(co
     private var hint: String = ""
     private var inputType: Int = 0
     private var text: String = ""
+    private var passwordToggleEnable = false
+
+    private var isVisiblePassword = false
 
     init {
         val typed = context.obtainStyledAttributes(attrs, R.styleable.TabooEditText)
@@ -53,6 +57,8 @@ class TabooEditText(context: Context, attrs: AttributeSet) : ConstraintLayout(co
         val text = typed.getString(R.styleable.TabooEditText_android_text) ?: ""
         val enabled = typed.getBoolean(R.styleable.TabooEditText_android_enabled, true)
 
+        val passwordToggleEnabled = typed.getBoolean(R.styleable.TabooEditText_passwordToggleEnabled, false)
+
         typed.recycle()
 
         setTitle(title)
@@ -70,8 +76,11 @@ class TabooEditText(context: Context, attrs: AttributeSet) : ConstraintLayout(co
 
         setHint(hint)
         setInputType(inputType)
+        setPasswordToggleEnabledInternal(passwordToggleEnabled)
         setText(text)
         setEnabled(enabled)
+
+        updatePasswordToggleEnabled()
     }
 
     fun setTitle(title: String) {
@@ -215,6 +224,46 @@ class TabooEditText(context: Context, attrs: AttributeSet) : ConstraintLayout(co
         val variation =
             inputType and (EditorInfo.TYPE_MASK_CLASS or EditorInfo.TYPE_MASK_VARIATION)
         return (variation == (EditorInfo.TYPE_CLASS_TEXT or EditorInfo.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD))
+    }
+
+    fun setPasswordToggleEnabledInternal(passwordToggleEnabled: Boolean) {
+        this.passwordToggleEnable = passwordToggleEnable
+    }
+
+    fun setPasswordToggleEnabled(passwordToggleEnabled: Boolean) {
+        setPasswordToggleEnabledInternal(passwordToggleEnabled)
+        updatePasswordToggleEnabled()
+    }
+
+    private fun updatePasswordToggleEnabled() {
+        val inputType = binding.edtText.inputType
+
+        if (isPasswordInputType(inputType) || isVisiblePasswordInputType(inputType)) {
+            val icon = AppCompatResources.getDrawable(context, R.drawable.ic_visibility_24dp_e5e8eb)?.mutate()
+            binding.ivPasswordToggle.setImageDrawable(icon)
+            binding.ivPasswordToggle.setColorFilter(context.getColor(R.color.taboo_gray_01))
+            binding.ivPasswordToggle.setOnClickListener {
+                val cursorPosition = binding.edtText.selectionStart
+
+                if (isVisiblePassword) {
+                    // 비밀번호 숨김
+                    binding.edtText.inputType = inputType
+                    binding.ivPasswordToggle.setColorFilter(context.getColor(R.color.taboo_gray_01))
+                } else {
+                    // 비밀번호 표시
+                    binding.edtText.inputType = EditorInfo.TYPE_CLASS_TEXT
+                    binding.ivPasswordToggle.setColorFilter(context.getColor(R.color.white))
+                }
+
+                // 상태값 변경
+                isVisiblePassword = !isVisiblePassword
+
+                // 커서 위치 변경
+                binding.edtText.setSelection(cursorPosition)
+            }
+        } else {
+            binding.ivPasswordToggle.setImageDrawable(null)
+        }
     }
 
     fun getText() = binding.edtText.text.toString()

--- a/Taboo/src/main/res/drawable/ic_visibility_24dp_e5e8eb.xml
+++ b/Taboo/src/main/res/drawable/ic_visibility_24dp_e5e8eb.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+
+    <path android:fillColor="@android:color/white" android:pathData="M12,4C7,4 2.73,7.11 1,11.5 2.73,15.89 7,19 12,19s9.27,-3.11 11,-7.5C21.27,7.11 17,4 12,4zM12,16.5c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5zM12,8.5c-1.66,0 -3,1.34 -3,3s1.34,3 3,3 3,-1.34 3,-3 -1.34,-3 -3,-3z"/>
+
+</vector>

--- a/Taboo/src/main/res/layout/taboo_edit_text.xml
+++ b/Taboo/src/main/res/layout/taboo_edit_text.xml
@@ -63,10 +63,14 @@
                 android:layout_width="0dp"
                 android:layout_height="52dp"
                 android:textColorHint="@color/selector_taboo_edit_text_hint"
+                android:inputType="text"
+                android:layout_marginHorizontal="5dp"
                 app:layout_constraintStart_toEndOf="@id/tv_prefix"
                 app:layout_constraintEnd_toStartOf="@id/tv_suffix"
                 app:layout_constraintTop_toTopOf="parent"
-                tools:hint="아이디를 입력해주세요." />
+                app:layout_goneMarginStart="0dp"
+                app:layout_goneMarginEnd="0dp"
+                tools:hint="아이디를 입력해주세요."/>
 
             <TextView
                 android:id="@+id/tv_suffix"
@@ -80,6 +84,15 @@
                 app:layout_constraintBottom_toBottomOf="parent"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <ImageView
+            android:id="@+id/iv_password_toggle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="15dp"
+            app:layout_constraintTop_toTopOf="@id/cl_edit_text_wrapper"
+            app:layout_constraintBottom_toBottomOf="@id/cl_edit_text_wrapper"
+            app:layout_constraintEnd_toEndOf="@id/cl_edit_text_wrapper"/>
         
         <TextView
             android:id="@+id/tv_error_message"

--- a/Taboo/src/main/res/layout/taboo_edit_text.xml
+++ b/Taboo/src/main/res/layout/taboo_edit_text.xml
@@ -41,6 +41,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@drawable/selector_taboo_edit_text"
+            android:paddingHorizontal="15dp"
             android:layout_marginTop="4dp"
             app:layout_constraintTop_toBottomOf="@id/cl_edit_text_title_wrapper"
             app:layout_constraintStart_toStartOf="parent">
@@ -58,26 +59,25 @@
 
             <EditText
                 android:id="@+id/edt_text"
+                style="@style/Taboo.Style.TabooEditText.Content"
                 android:layout_width="0dp"
                 android:layout_height="52dp"
-                style="@style/Taboo.Style.TabooEditText.Content"
                 android:textColorHint="@color/selector_taboo_edit_text_hint"
-                tools:hint="아이디를 입력해주세요."
-                app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintStart_toEndOf="@id/tv_prefix"
                 app:layout_constraintEnd_toStartOf="@id/tv_suffix"
-                app:layout_goneMarginStart="15dp"
-                app:layout_goneMarginEnd="15dp"/>
+                app:layout_constraintTop_toTopOf="parent"
+                tools:hint="아이디를 입력해주세요." />
 
             <TextView
                 android:id="@+id/tv_suffix"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                style="@style/Taboo.Style.TabooEditText.Suffix"
                 android:visibility="gone"
+                style="@style/Taboo.Style.TabooEditText.Suffix"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintStart_toEndOf="@id/edt_text"
-                app:layout_constraintEnd_toEndOf="parent"/>
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
         

--- a/Taboo/src/main/res/values/attrs.xml
+++ b/Taboo/src/main/res/values/attrs.xml
@@ -73,6 +73,8 @@
         <attr name="suffixText" format="string"/>
         <attr name="suffixTextAppearance" format="reference"/>
         <attr name="suffixTextColor" format="reference|color"/>
+
+        <attr name="passwordToggleEnabled" format="boolean"/>
     </declare-styleable>
 
     <declare-styleable name="TabooHorizontalCalender">

--- a/Taboo/src/main/res/values/themes.xml
+++ b/Taboo/src/main/res/values/themes.xml
@@ -166,18 +166,12 @@
 
     <style name="Taboo.Style.TabooEditText.Prefix">
         <item name="android:textAppearance">@style/Taboo.TextAppearance.TabooEditText.Affix</item>
-        <item name="android:layout_marginTop">15dp</item>
-        <item name="android:layout_marginStart">15dp</item>
-        <item name="android:layout_marginBottom">15dp</item>
         <item name="android:layout_marginEnd">5dp</item>
     </style>
 
     <style name="Taboo.Style.TabooEditText.Suffix">
         <item name="android:textAppearance">@style/Taboo.TextAppearance.TabooEditText.Affix</item>
-        <item name="android:layout_marginTop">15dp</item>
         <item name="android:layout_marginStart">5dp</item>
-        <item name="android:layout_marginBottom">15dp</item>
-        <item name="android:layout_marginEnd">15dp</item>
     </style>
 
     <style name="Taboo.Style.TabooEditText.Content">

--- a/Taboo/src/main/res/values/themes.xml
+++ b/Taboo/src/main/res/values/themes.xml
@@ -166,12 +166,10 @@
 
     <style name="Taboo.Style.TabooEditText.Prefix">
         <item name="android:textAppearance">@style/Taboo.TextAppearance.TabooEditText.Affix</item>
-        <item name="android:layout_marginEnd">5dp</item>
     </style>
 
     <style name="Taboo.Style.TabooEditText.Suffix">
         <item name="android:textAppearance">@style/Taboo.TextAppearance.TabooEditText.Affix</item>
-        <item name="android:layout_marginStart">5dp</item>
     </style>
 
     <style name="Taboo.Style.TabooEditText.Content">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.6.0" apply false
+    id("com.android.application") version "8.8.0" apply false
     id("org.jetbrains.kotlin.android") version "1.9.0" apply false
-    id("com.android.library") version "8.6.0" apply false
+    id("com.android.library") version "8.8.0" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 10 20:39:55 KST 2024
+#Tue Feb 11 07:32:35 KST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- `android:inputType`이 `numberPassword` 또는 `textPassword`일 때, 힌트 폰트가 기본 폰트로 변경되는 이슈 수정.  
- `passwordToggleEnabled` 속성 추가:  
  - `android:inputType`이 `numberPassword` 또는 `textPassword`일 때, 비밀번호 표시/숨김을 전환할 수 있는 아이콘 제공.  
