### PR TITLE
[Issue] HAMS-67 TabooTextField > 엔터 키를 입력해도 다음 컴포넌트로 포커스가 이동하지 않는 이슈 수정

### DIFF
--- a/Taboo/src/main/java/com/kwon/taboo/textfield/TabooTextField.kt
+++ b/Taboo/src/main/java/com/kwon/taboo/textfield/TabooTextField.kt
@@ -29,10 +29,6 @@ open class TabooTextField(
             editTextOnFocusChangeListener?.onFocusChange(v, hasFocus)
             textFieldWrapper.isSelected = hasFocus
         }
-
-        setOnClickListener { v ->
-            editTextOnClickListener?.onClick(v)
-        }
     }
 
     private var editTextOnFocusChangeListener: OnFocusChangeListener? = null
@@ -111,8 +107,16 @@ open class TabooTextField(
         editTextOnFocusChangeListener = l
     }
 
+    /**
+     * 텍스트 입력 필드의 클릭 리스너 설정 메소드.
+     *
+     * 텍스트 입력을 하기 위한 [EditText]에 클릭 리스너를 등록하면 [EditorInfo.IME_ACTION_NEXT] 옵션이 동작하지 않는다.
+     * 드랍다운의 경우, 클릭 리스너를 등록해서 팝업을 띄우기 때문에 필수로 등록해야하지만 텍스트 입력을 해야하는 일반적인 상황에서는 권장하지 않는다.
+     */
     fun setOnClickListener(l: OnClickListener?) {
-        editTextOnClickListener = l
+        editText.setOnClickListener {
+            l?.onClick(it)
+        }
     }
 
     fun setOnTextChangedListener(l: (text: CharSequence, start: Int, before: Int, count: Int) -> Unit) {


### PR DESCRIPTION
### 원인

`EditText`에 `setOnClickListener()`를 주는 경우, `EditorInfo.IME_ACTION_NEXT`가 동작하지 않음.

### 해결

Dropdown 일 때만 `setOnClickListener()`를 등록하도록  수정함. 