### PR TITLE
[Function] TabooPreviewButton 레이아웃 수정 및 기능 추가

### DIFF
--- a/Taboo/src/main/java/com/kwon/taboo/button/TabooPreviewButton.kt
+++ b/Taboo/src/main/java/com/kwon/taboo/button/TabooPreviewButton.kt
@@ -6,6 +6,11 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.ConstraintSet
+import androidx.constraintlayout.widget.ConstraintSet.BOTTOM
+import androidx.constraintlayout.widget.ConstraintSet.END
+import androidx.constraintlayout.widget.ConstraintSet.START
+import androidx.constraintlayout.widget.ConstraintSet.TOP
 import androidx.core.content.ContextCompat
 import com.kwon.taboo.R
 import com.kwon.taboo.databinding.TabooPreviewButtonBinding
@@ -16,6 +21,7 @@ class TabooPreviewButton(context: Context, attrs: AttributeSet) : ConstraintLayo
     private var text = "Preview Button"
     private var description = "Preview Button Description"
     private var preview = "Preview"
+    private var previewGravity: Int = PREVIEW_GRAVITY_TOP
     private var iconResource: Drawable? = null
 
     init {
@@ -24,6 +30,7 @@ class TabooPreviewButton(context: Context, attrs: AttributeSet) : ConstraintLayo
         val text = typed.getString(R.styleable.TabooPreviewButton_android_text) ?: "Preview Button"
         val description = typed.getString(R.styleable.TabooPreviewButton_description) ?: "Preview Button Description"
         val preview = typed.getString(R.styleable.TabooPreviewButton_preview) ?: "Preview"
+        val previewGravity = typed.getInt(R.styleable.TabooPreviewButton_previewGravity, PREVIEW_GRAVITY_TOP)
         val iconResourceId = typed.getResourceId(R.styleable.TabooPreviewButton_icon, R.drawable.ic_default_icon)
 
         typed.recycle()
@@ -32,6 +39,7 @@ class TabooPreviewButton(context: Context, attrs: AttributeSet) : ConstraintLayo
         setText(text)
         setDescription(description)
         setPreview(preview)
+        setPreviewGravity(previewGravity)
         setIconResourceId(iconResourceId)
 
         binding.root.background = ContextCompat.getDrawable(context, R.drawable.taboo_button_ripple_effect)
@@ -73,6 +81,41 @@ class TabooPreviewButton(context: Context, attrs: AttributeSet) : ConstraintLayo
         binding.tvButtonPreview.text = preview
     }
 
+    fun getPreviewGravity() = previewGravity
+
+    fun setPreviewGravity(previewGravity: Int) {
+        this.previewGravity = previewGravity
+        updatePreviewGravity()
+    }
+
+    private fun updatePreviewGravity() {
+        val constraintSet = ConstraintSet()
+        constraintSet.clone(binding.wrapper)
+        val previewContainerId = binding.clPreviewContainer.id
+        val parentId = binding.wrapper.id
+
+        when (previewGravity) {
+            PREVIEW_GRAVITY_TOP -> {
+                constraintSet.connect(previewContainerId, TOP, parentId, TOP)
+                constraintSet.connect(previewContainerId, END, parentId, END)
+                constraintSet.connect(previewContainerId, BOTTOM, -1, BOTTOM)
+            }
+            PREVIEW_GRAVITY_CENTER -> {
+                constraintSet.connect(previewContainerId, TOP, parentId, TOP)
+                constraintSet.connect(previewContainerId, BOTTOM, parentId, BOTTOM)
+            }
+            PREVIEW_GRAVITY_BOTTOM -> {
+                constraintSet.connect(previewContainerId, TOP, -1, TOP)
+                constraintSet.connect(previewContainerId, END, parentId, END)
+                constraintSet.connect(previewContainerId, BOTTOM, parentId, BOTTOM)
+            }
+        }
+
+        constraintSet.connect(previewContainerId, START, binding.clButtonInformationContainer.id, END)
+
+        constraintSet.applyTo(binding.wrapper)
+    }
+
     fun setIconResourceId(resourceId: Int) {
         this.iconResource = ContextCompat.getDrawable(context, resourceId)
         updateIconResource()
@@ -91,17 +134,9 @@ class TabooPreviewButton(context: Context, attrs: AttributeSet) : ConstraintLayo
         super.setOnClickListener(l)
     }
 
-//    override fun onTouchEvent(event: MotionEvent?): Boolean {
-//        when (event?.action) {
-//            MotionEvent.ACTION_DOWN -> isPressed = true
-//            MotionEvent.ACTION_UP -> performClick()
-//            MotionEvent.ACTION_CANCEL -> isPressed = false
-//        }
-//
-//        return super.onTouchEvent(event)
-//    }
-//
-//    override fun performClick(): Boolean {
-//        return super.performClick()
-//    }
+    companion object {
+        const val PREVIEW_GRAVITY_TOP = 0
+        const val PREVIEW_GRAVITY_CENTER = 1
+        const val PREVIEW_GRAVITY_BOTTOM = 2
+    }
 }

--- a/Taboo/src/main/res/layout/taboo_preview_button.xml
+++ b/Taboo/src/main/res/layout/taboo_preview_button.xml
@@ -9,19 +9,19 @@
 
         <ImageView
             android:id="@+id/iv_button_icon"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:src="@drawable/ic_default_icon"
             style="@style/Taboo.Style.ImageView"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"/>
 
+        <!-- 타이틀 및 설명 영역 -->
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_button_information_container"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="10dp"
-            app:layout_constraintWidth_percent="0.65"
+            android:layout_marginHorizontal="10dp"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toEndOf="@id/iv_button_icon"
             app:layout_constraintEnd_toStartOf="@id/cl_preview_container">
@@ -43,10 +43,11 @@
                 app:layout_constraintTop_toBottomOf="@id/tv_button_name"/>
             
         </androidx.constraintlayout.widget.ConstraintLayout>
-        
+
+        <!-- 미리보기 영역 -->
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_preview_container"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toEndOf="@id/cl_button_information_container"
@@ -56,7 +57,7 @@
                 android:id="@+id/tv_button_preview"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="PREVIEW"
+                android:text="Preview"
                 style="@style/Taboo.TextAppearance.PreviewButton.Preview"
                 android:layout_marginEnd="7dp"
                 app:layout_constraintTop_toTopOf="parent"

--- a/Taboo/src/main/res/layout/taboo_preview_button.xml
+++ b/Taboo/src/main/res/layout/taboo_preview_button.xml
@@ -2,6 +2,7 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/wrapper"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@drawable/taboo_button_ripple_effect"

--- a/Taboo/src/main/res/values/attrs.xml
+++ b/Taboo/src/main/res/values/attrs.xml
@@ -52,6 +52,11 @@
         <attr name="descriptionTextAppearance" format="reference"/>
         <attr name="preview" format="string"/>
         <attr name="previewTextAppearance" format="reference"/>
+        <attr name="previewGravity" format="integer">
+            <enum name="top" value="0"/>
+            <enum name="center" value="1"/>
+            <enum name="bottom" value="2"/>
+        </attr>
         <attr name="icon"/>
     </declare-styleable>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,9 @@
         android:theme="@style/Theme.TabooSample"
         tools:targetApi="31">
         <activity
+            android:name=".PreviewButtonsActivity"
+            android:exported="false" />
+        <activity
             android:name=".TabsActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/java/com/kwon/taboosample/MainActivity.kt
+++ b/app/src/main/java/com/kwon/taboosample/MainActivity.kt
@@ -41,5 +41,9 @@ class MainActivity : AppCompatActivity() {
         findViewById<Button>(R.id.btn_numbering_ball_example).setOnClickListener {
             startActivity(Intent(this, NumberingBallsActivity::class.java))
         }
+
+        findViewById<Button>(R.id.btn_preview_button_example).setOnClickListener {
+            startActivity(Intent(this, PreviewButtonsActivity::class.java))
+        }
     }
 }

--- a/app/src/main/java/com/kwon/taboosample/PreviewButtonsActivity.kt
+++ b/app/src/main/java/com/kwon/taboosample/PreviewButtonsActivity.kt
@@ -1,0 +1,20 @@
+package com.kwon.taboosample
+
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+class PreviewButtonsActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContentView(R.layout.activity_preview_buttons)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -70,4 +70,12 @@
         app:layout_constraintTop_toBottomOf="@id/btn_tab_example"
         app:layout_constraintStart_toStartOf="parent"/>
 
+    <Button
+        android:id="@+id/btn_preview_button_example"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="PREVIEW BUTTON"
+        app:layout_constraintTop_toBottomOf="@id/btn_numbering_ball_example"
+        app:layout_constraintStart_toStartOf="parent"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_preview_buttons.xml
+++ b/app/src/main/res/layout/activity_preview_buttons.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".PreviewButtonsActivity">
+
+    <com.kwon.taboo.button.TabooPreviewButton
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:previewGravity="bottom"/>
+
+</LinearLayout>


### PR DESCRIPTION
- 아이콘의 크기 제한이 없도록 수정함.
- Preview 표시 영역 위치를 변경 할 수 있도록 `previewGravity` 속성 추가
    - `top`: 상단에 표시(기본값).
    - `center`: 중간에 표시. 
    - `bottom`: 하단에 표시.
    > `center` 와 `bottom`은 버튼 높이에 따라 표시되는 위치가 동적으로 변하므라 UI를 고려하여 선택해야 함.