### PR TITLE
TabooTextButton > iconScaleType 속성 추가

### DIFF
--- a/app/src/main/res/layout/activity_buttons.xml
+++ b/app/src/main/res/layout/activity_buttons.xml
@@ -124,31 +124,6 @@
             android:layout_marginTop="10dp"
             app:title="English"
             app:description="영어"/>
-
-        <com.kwon.taboo.button.TabooMenuButton
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/white"
-            android:layout_marginTop="10dp"/>
-
-        <com.kwon.taboo.button.TabooMenuButton
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/white"
-            android:layout_marginTop="10dp"/>
-
-        <com.kwon.taboo.button.TabooMenuButton
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/white"
-            android:layout_marginTop="10dp"/>
-
-        <com.kwon.taboo.button.TabooMenuButton
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/white"
-            android:layout_marginTop="10dp"/>
-
         <com.kwon.taboo.button.TabooMenuButton
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -167,7 +142,15 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="장비 추가하기"
-            app:icon="@drawable/ic_add_24" />
+            app:icon="@drawable/ic_add_24"
+            app:iconScaleType="fix"/>
+
+        <com.kwon.taboo.button.TabooTextButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="장비 추가하기"
+            app:icon="@drawable/ic_add_24"
+            app:iconScaleType="fit"/>
 
         <com.kwon.taboo.button.TabooTextButton
             android:layout_width="wrap_content"

--- a/taboo-widget/src/main/java/com/kwon/taboo/button/TabooTextButton.kt
+++ b/taboo-widget/src/main/java/com/kwon/taboo/button/TabooTextButton.kt
@@ -55,6 +55,8 @@ class TabooTextButton @JvmOverloads constructor(
     @IconPosition
     private var iconPosition = IconPosition.ICON_LEFT
 
+    private var iconScaleType = IconScaleType.FIX
+
     private var contentSpace = CONTENT_SPACE_DP
 
     init {
@@ -98,6 +100,9 @@ class TabooTextButton @JvmOverloads constructor(
             val iconTint = getColorStateList(R.styleable.TabooTextButton_iconTint)
             setImageTintList(iconTint)
 
+            // Icon Scale Type
+            setIconScaleType(getInt(R.styleable.TabooTextButton_iconScaleType, IconScaleType.FIX))
+
             // Icon 위치
             setIconPosition(getInt(R.styleable.TabooTextButton_iconPosition, IconPosition.ICON_LEFT))
 
@@ -136,6 +141,27 @@ class TabooTextButton @JvmOverloads constructor(
 
     fun setIconBackgroundColors(colors: ColorStateList) {
         iconImageView.backgroundTintList = colors
+    }
+
+    private fun setIconScaleTypeInternal(@IconScaleType iconScaleType: Int) {
+        this.iconScaleType = iconScaleType
+    }
+
+    fun setIconScaleType(@IconScaleType iconScaleType: Int) {
+        setIconScaleTypeInternal(iconScaleType)
+
+        updateIconLayoutParams()
+    }
+
+    private fun updateIconLayoutParams() {
+        val params = iconImageView.layoutParams as LayoutParams
+        iconImageView.layoutParams = params.apply {
+            println("scaleType: $iconScaleType")
+            val size = if (iconScaleType == IconScaleType.FIX) ResourceUtils.dpToPx(context, IMAGE_VIEW_SIZE) else LayoutParams.WRAP_CONTENT
+            println("size: $size")
+            width = size
+            height = size
+        }
     }
 
     fun setImageTintList(color: ColorStateList?) {
@@ -189,6 +215,13 @@ class TabooTextButton @JvmOverloads constructor(
             lp.marginStart = if (iconPosition == IconPosition.ICON_LEFT) margin else 0
             lp.marginEnd = if (iconPosition == IconPosition.ICON_RIGHT) margin else 0
             textView.layoutParams = lp
+        }
+    }
+
+    annotation class IconScaleType {
+        companion object {
+            const val FIX = 0
+            const val FIT = 1
         }
     }
 

--- a/taboo-widget/src/main/res/values/attrs.xml
+++ b/taboo-widget/src/main/res/values/attrs.xml
@@ -58,6 +58,10 @@
         <attr name="icon"/>
         <attr name="iconPosition"/>
         <attr name="iconBackgroundColor" format="reference|color"/>
+        <attr name="iconScaleType" format="enum">
+            <enum name="fix" value="0"/>
+            <enum name="fit" value="1"/>
+        </attr>
         <attr name="iconTint" format="reference|color"/>
         <attr name="contentSpace" format="dimension"/>
     </declare-styleable>


### PR DESCRIPTION
### 변경 사항
- `iconScaleType` 속성 추가
   - `fix`: 아이콘의 크기가 `36dp`로 고정
   - `fit`: 아이콘 크기가 `WRAP_CONTENT`로 동작