### PR TITLE
TABOO-114 TabooSegmentTab > 탭 신규 추가 시 탭의 텍스트 사이즈 타입을 COMPLEX_UNIT_PX로 설정

### DIFF
--- a/taboo-widget/src/main/java/com/kwon/taboo/segment/TabooSegmentTab.kt
+++ b/taboo-widget/src/main/java/com/kwon/taboo/segment/TabooSegmentTab.kt
@@ -164,7 +164,7 @@ class TabooSegmentTab @JvmOverloads constructor(
                 setPadding(padding, padding, padding, padding)
                 setTypeface(ResourcesCompat.getFont(context, tabFontFamily))
                 setTextColor(tabTextColor)
-                textSize = tabTextSizePixel
+                setTextSize(TypedValue.COMPLEX_UNIT_PX, tabTextSizePixel)
                 setOnClickListener {
                     onTabSelectedListener?.invoke(index)
 


### PR DESCRIPTION
### 수정 사항
- 탭 신규 추가 시 탭의 텍스트 사이즈 타입이 COMPLEXT_UNIT_SP로 설정되어 inflate 시 텍스트 사이즈가 크게 적용된 이슈 수정